### PR TITLE
Badly formatted exception upon wrong python version

### DIFF
--- a/paperwork_backend/deps.py
+++ b/paperwork_backend/deps.py
@@ -55,7 +55,7 @@ def check_python_version():
     if python_ver < (3, 0):
         raise Exception(
             "Expected python >= 3.0 !"
-            "Got python {}".format(".".join(python_ver))
+            "Got python {}".format(sys.version)
         )
     return []
 


### PR DESCRIPTION
I have:
```
  File "/home/teto/.local/bin/paperwork-shell", line 9, in <module>
    load_entry_point('paperwork-backend', 'console_scripts', 'paperwork-shell')()
  File "/home/teto/paperwork-backend/paperwork_backend/shell_cmd.py", line 189, in main
    sys.exit(COMMANDS[args.cmd](*args.cmd_args))
  File "/home/teto/paperwork-backend/paperwork_backend/shell_cmd.py", line 131, in chkdeps
    _chkdeps(module_name, distribution)
  File "/home/teto/paperwork-backend/paperwork_backend/shell_cmd.py", line 78, in _chkdeps
    missing = module.find_missing_dependencies()
  File "/home/teto/paperwork-backend/paperwork_backend/deps.py", line 80, in find_missing_dependencies
    missing += check_python_version()
  File "/home/teto/paperwork-backend/paperwork_backend/deps.py", line 58, in check_python_version
    "Got python {}".format(".".join(python_ver))
TypeError: sequence item 0: expected string, int found
```

After this patch, I get proper feedback:

```
Traceback (most recent call last):
  File "/home/teto/.local/bin/paperwork-shell", line 9, in <module>
    load_entry_point('paperwork-backend', 'console_scripts', 'paperwork-shell')()
  File "/home/teto/paperwork-backend/paperwork_backend/shell_cmd.py", line 189, in main
    sys.exit(COMMANDS[args.cmd](*args.cmd_args))
  File "/home/teto/paperwork-backend/paperwork_backend/shell_cmd.py", line 131, in chkdeps
    _chkdeps(module_name, distribution)
  File "/home/teto/paperwork-backend/paperwork_backend/shell_cmd.py", line 78, in _chkdeps
    missing = module.find_missing_dependencies()
  File "/home/teto/paperwork-backend/paperwork_backend/deps.py", line 80, in find_missing_dependencies
    missing += check_python_version()
  File "/home/teto/paperwork-backend/paperwork_backend/deps.py", line 58, in check_python_version
    "Got python {}".format(sys.version)
Exception: Expected python >= 3.0 !Got python 2.7.13 (default, Jan 19 2017, 14:48:08)
[GCC 6.3.0 20170118]
```